### PR TITLE
Add library matching package name

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,5 +1,8 @@
 #+TITLE: Eziam Theme
 
+*This package has been renamed from ~eziam-theme~ to ~eziam-themes~ (plural).*
+*To get updates, you must uninstall the former and install the latter.*
+
 *I probably don't use Eziam anymore.*
 
 I will try to fix bugs as get reported, but nothing more.

--- a/eziam-dark-theme.el
+++ b/eziam-dark-theme.el
@@ -33,7 +33,7 @@
 
 ;;; Code:
 
-(require 'eziam-common)
+(require 'eziam-themes)
 
 (deftheme eziam-dark "The dark Eziam color theme")
 

--- a/eziam-dusk-theme.el
+++ b/eziam-dusk-theme.el
@@ -33,7 +33,7 @@
 
 ;;; Code:
 
-(require 'eziam-common)
+(require 'eziam-themes)
 
 (deftheme eziam-dusk "The dusk Eziam color theme")
 

--- a/eziam-light-theme.el
+++ b/eziam-light-theme.el
@@ -33,7 +33,7 @@
 
 ;;; Code:
 
-(require 'eziam-common)
+(require 'eziam-themes)
 
 (deftheme eziam-light "The light Eziam color theme")
 

--- a/eziam-theme-pkg.el
+++ b/eziam-theme-pkg.el
@@ -1,4 +1,0 @@
-(define-package
-  "eziam-theme"
-  "0.1"
-  "A mostly monochrome theme, inspired by Tao and Leuven, with dark and light versions.")

--- a/eziam-themes-pkg.el
+++ b/eziam-themes-pkg.el
@@ -1,0 +1,2 @@
+(define-package "eziam-themes" "0.1"
+  "The mostly monochrome Eziam theme family.")

--- a/eziam-themes.el
+++ b/eziam-themes.el
@@ -1,4 +1,4 @@
-;;; eziam-common.el --- Common tools and face assignment table for Eziam
+;;; eziam-themes.el --- The mostly monochrome Eziam theme family
 
 ;; Copyright (c) 2016-2020 Thibault Polge <thibault@thb.lt>
 
@@ -29,8 +29,8 @@
 
 ;;; Commentary:
 
-;; This package provides a dark and a light version of the Eziam theme
-;; for Emacs.
+;; This package provides several mostly monochrome theme family in the
+;; Eziam family, which were inspired by the Tao and Leuven themes.
 
 ;;; Code:
 
@@ -1113,5 +1113,5 @@ block using `eziam-with-color-variables'."
      `(vc-annotate-background ,color-1))
     ))
 
-(provide 'eziam-common)
-;;; eziam-common.el ends here
+(provide 'eziam-themes)
+;;; eziam-themes.el ends here


### PR DESCRIPTION
Every package should provide a library whose name matches that of the
package.  This allows tools, such as those used by Melpa, to extract
metadata.

At the same time every library named `*-theme.el` must itself
implement a theme because `load-theme` unfortunately assumes that
every file on `custom-theme-load-path` with such a name actually
provides a theme.  If it encounters files that to not provide a theme
but are never-the-less named `*-theme`, then it falsely offers those
as themes that can be activated.

Furthermore, since this package provides multiple themes, it makes
sense to give it a name that suggests so.

Unfortunately package.el does not (yet?) support informing the user
about package renames or even automatically updating to the new name,
so some users will not notice this rename for a while.  Add a note
at the beginning of the readme, in the hope that will help at least
some users.